### PR TITLE
Handle already-aborted signal to match native fetch behavior

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -72,6 +72,12 @@ export function fetchEventSource(input: RequestInfo, {
         : () => ({ ...(inputHeaders ?? {}) });
 
     return new Promise<void>((resolve, reject) => {
+        // Handle already-aborted signal immediately to match native fetch behavior
+        if (inputSignal?.aborted) {
+            resolve();
+            return;
+        }
+
         // Track last-event-id separately so it persists across retries even with dynamic headers
         let lastEventId: string | undefined;
 

--- a/test/fetch.spec.ts
+++ b/test/fetch.spec.ts
@@ -297,6 +297,25 @@ describe('fetch', () => {
             await expect(promise).resolves.toBeUndefined();
         });
 
+        it('should resolve immediately when signal is already aborted (issue #98)', async () => {
+            const controller = new AbortController();
+            controller.abort(); // Abort before calling fetchEventSource
+
+            const mockFetch = jest.fn().mockResolvedValue(
+                createMockResponse('data: test\n\n')
+            );
+
+            const promise = fetchEventSource('http://test.com/sse', {
+                fetch: mockFetch,
+                signal: controller.signal,
+                openWhenHidden: true
+            });
+
+            await expect(promise).resolves.toBeUndefined();
+            // fetch should never be called since signal was already aborted
+            expect(mockFetch).not.toHaveBeenCalled();
+        });
+
         it('should retry on error with default interval', async () => {
             let callCount = 0;
             const mockFetch = jest.fn().mockImplementation(() => {


### PR DESCRIPTION
## Summary

- Check if `inputSignal.aborted` is true at the start of `fetchEventSource` and resolve immediately if so
- This matches native `fetch` behavior where passing an already-aborted signal rejects immediately
- Previously, the library only listened for future 'abort' events, causing already-aborted signals to hang indefinitely

Fixes #6 (Azure/fetch-event-source#98)

## Test plan

- [x] Added test verifying that an already-aborted signal resolves immediately without making any fetch calls
- [x] All existing tests pass